### PR TITLE
Add unit declarator to module and role declarations

### DIFF
--- a/lib/Masquerade.pm6
+++ b/lib/Masquerade.pm6
@@ -1,4 +1,4 @@
-module Masquerade;
+unit module Masquerade;
 
 use Masquerade::AsIf::JSON;
 use Masquerade::AsIf::Perl;

--- a/lib/Masquerade/AsIf/JSON.pm6
+++ b/lib/Masquerade/AsIf/JSON.pm6
@@ -1,7 +1,7 @@
 # JSON::Tiny is used to render basic stuff like hashes.
 use JSON::Tiny;
 
-role AsIf::JSON;
+unit role AsIf::JSON;
 
 # For reasons I don't quite understand, this has to be separated out into
 # it's own sub right now.  I'd probably really just fold it into Str.

--- a/lib/Masquerade/AsIf/Perl.pm6
+++ b/lib/Masquerade/AsIf/Perl.pm6
@@ -1,7 +1,7 @@
 # JSON::Tiny is used to render basic stuff like hashes.
 use JSON::Tiny;
 
-role AsIf::Perl;
+unit role AsIf::Perl;
 
 # Tries to interpret the thing you're doing as a JSON object string.
 # Obviously this won't work if it's not one, so don't do that.

--- a/lib/Masquerade/AsIf/YAML.pm
+++ b/lib/Masquerade/AsIf/YAML.pm
@@ -1,5 +1,5 @@
 
-role AsIf::YAML;
+unit role AsIf::YAML;
 
 ##
 # This helper sub renders class-based objects as JSON.  Objects are treated


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
