### PR TITLE
Compare .perl output via from-json in asif JSON tests

### DIFF
--- a/t/asif-json.t
+++ b/t/asif-json.t
@@ -10,8 +10,10 @@ my $expected;
 
 # A utility sub to test.  Pass in the object, expected result, and test
 # description to run the test.
+use JSON::Tiny;
 sub test_json ($obj, Str $expected, Str $explanation) {
-  ok ($obj but AsIf::JSON eq $expected), $explanation;
+  my $obj-asif-json = $obj but AsIf::JSON;
+  is from-json($obj-asif-json.Str).perl, from-json($expected).perl, $explanation;
 }
 
 #####


### PR DESCRIPTION
Since hashes don't have a definite ordering, the asif JSON tests don't
compare reliably.  This change uses JSON::Tiny to construct a Perl 6 object
from the output and expected JSON which can then be compared via the .perl
method.  This representation seems to be more stable than comparing the JSON
strings to one another.  Nevertheless, there needs to be a way to compare
deep JSON structures with one another, it just doesn't exist in the Perl 6
world just yet (e.g. JSON::Tiny explicitly doesn't handle it at this stage).
