### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
   "name"        : "Masquerade",
+  "license"     : "Artistic-2.0",
   "version"     : "*",
   "description" : "Let Perl 6 constructs masquerade as other things.",
   "provides"    : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license